### PR TITLE
switch ESLint filename case to camelCase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,13 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'max-lines-per-function': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    'react/require-default-props': 'off',
+    'unicorn/filename-case': [
+      'error',
+      {
+        case: 'camelCase',
+      },
+    ],
     'prettier/prettier': [
       'error',
       {


### PR DESCRIPTION
ESLint Unicorn was enforcing kebab-case by default so I changed it to camelCase