### PR TITLE
Add service worker that deletes itself

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-restricted-globals */
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', () => {
+  self.registration
+    .unregister()
+    .then(() => self.clients.matchAll())
+    .then((clients) => {
+      clients.forEach((client) => client.navigate(client.url));
+    });
+});


### PR DESCRIPTION
This should install on top of the pre-existing service worker from the 2021 site which is causing weird cache issues. Then, it should delete itself, meaning no more caching issues.