### PR TITLE
add hover media query mixin

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -72,3 +72,17 @@
     margin-top: $distance;
   }
 }
+
+// devices with hover enabled (mouse, trackpad)
+@mixin hover {
+  @media (hover: hover) {
+    @content;
+  }
+}
+
+// devices with no hover capabilities (phone, tablet)
+@mixin touch {
+  @media (hover: none) {
+    @content;
+  }
+}


### PR DESCRIPTION
Needed to only enable hover effects on devices that support hover and only enable certain styles (visible underline) for touch devices. This is better than relying on screen size media queries.

Usage:

```scss
@use "/src/styles/mixins" as *;

...

@include hover {
  .someClass:hover {
    // styles that will only be applied on devices that support hover
  }
}

@include touch {
  .anotherClass {
    // styles that will only be applied on touch devices
  }
}
```